### PR TITLE
hotfix: bump SSL cert name to v5 to match teaching state

### DIFF
--- a/infra/environments/teaching/terraform.tfvars
+++ b/infra/environments/teaching/terraform.tfvars
@@ -11,7 +11,7 @@ enable_ha   = false
 
 cloud_run_max_instances = 5
 
-lb_domains = ["teaching.quill-medical.com"]
+lb_domains     = ["teaching.quill-medical.com"]
 landing_domain = "quill-medical.com"
 
 backend_image  = "gcr.io/cloudrun/hello:latest"

--- a/infra/modules/load-balancer/main.tf
+++ b/infra/modules/load-balancer/main.tf
@@ -189,7 +189,7 @@ resource "google_compute_backend_bucket" "landing" {
 # ---------- Google-managed SSL certificate ----------
 resource "google_compute_managed_ssl_certificate" "cert" {
   project = var.project_id
-  name    = "quill-cert-v4-${var.environment}"
+  name    = "quill-cert-v5-${var.environment}"
 
   managed {
     domains = concat(var.domains, var.landing_domain != null ? [var.landing_domain, "www.${var.landing_domain}"] : [])


### PR DESCRIPTION
The teaching SSL cert was replaced locally (v4 deleted, v5 created) to add quill-medical.com and www.quill-medical.com domains. This aligns the code with the current Terraform state to prevent 409 conflicts on the next CI apply.