### PR TITLE
fix: add frame-src CSP directive to allow YouTube embeds

### DIFF
--- a/caddy/prod/Caddyfile
+++ b/caddy/prod/Caddyfile
@@ -22,7 +22,7 @@
 		# HSTS — tell browsers to always use HTTPS (2 years)
 		Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"
 		# CSP — only allow resources from our own domain
-		Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://storage.googleapis.com; font-src 'self'; connect-src 'self'; frame-ancestors 'none'"
+		Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://storage.googleapis.com; font-src 'self'; connect-src 'self'; frame-src 'self' https://www.youtube.com; frame-ancestors 'none'"
 		# Prevent clickjacking
 		X-Frame-Options "DENY"
 		# Prevent MIME-type sniffing


### PR DESCRIPTION
The teaching video player uses an iframe to embed YouTube content. Without an explicit frame-src directive, the default-src 'self' policy blocks the YouTube iframe, showing a 'content blocked' message.