### PR TITLE
fix(ci): fix deploy workflow failures

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -109,6 +109,13 @@ jobs:
         with:
           ref: ${{ needs.prepare.outputs.sha }}
 
+      - name: Checkout teaching-tooling
+        if: ${{ matrix.changed == 'true' && matrix.service == 'backend' }}
+        uses: actions/checkout@v6
+        with:
+          repository: bailey-medics/teaching-tooling
+          path: teaching-tooling
+
       - name: Authenticate to GCP (teaching)
         if: ${{ matrix.changed == 'true' }}
         uses: google-github-actions/auth@v3

--- a/.github/workflows/public-site.yml
+++ b/.github/workflows/public-site.yml
@@ -85,9 +85,9 @@ jobs:
           gsutil -m -h "Cache-Control:public, max-age=31536000, immutable" \
             rsync -r -x '.*\.html$' public-site/assets/ "gs://${BUCKET}/assets/"
 
-          # Upload static assets (images, icons, manifest, service worker)
+          # Upload static assets (images, icons, manifest)
           gsutil -m -h "Cache-Control:public, max-age=2592000" \
-            cp public-site/*.png public-site/*.ico public-site/*.webmanifest public-site/*.js "gs://${BUCKET}/"
+            cp public-site/*.png public-site/*.ico public-site/*.webmanifest "gs://${BUCKET}/"
 
           # Upload HTML files with no-cache
           gsutil -m -h "Cache-Control:no-cache" \


### PR DESCRIPTION
- deploy.yml: add teaching-tooling checkout before backend Docker build (COPY teaching-tooling/scripts requires it in the build context)
- public-site.yml: remove *.js glob from gsutil cp (no root-level JS files exist, causing CommandException: No URLs matched)