### PR TITLE
fix(teaching): discover GCS banks with assessment.yaml not just confi…

### DIFF
--- a/backend/app/features/teaching/storage.py
+++ b/backend/app/features/teaching/storage.py
@@ -333,14 +333,14 @@ def list_banks_in_gcs(bucket_name: str) -> list[str]:
     """List available question bank IDs in a GCS bucket.
 
     Looks for top-level directories under ``questions/`` that contain
-    a ``config.yaml`` file.
+    an ``assessment.yaml`` or ``config.yaml`` file.
     """
     from google.cloud import storage  # type: ignore[import-untyped]
 
     client = storage.Client()
     bucket = client.bucket(bucket_name)
 
-    # List blobs matching questions/*/config.yaml
+    # List top-level directories under questions/
     prefix = "questions/"
     blobs = bucket.list_blobs(prefix=prefix, delimiter="/")
 
@@ -352,9 +352,10 @@ def list_banks_in_gcs(bucket_name: str) -> list[str]:
         # p looks like "questions/chest-xray-interpretation/"
         bank_id = p.removeprefix(prefix).rstrip("/")
         if bank_id and _SAFE_BANK_ID.match(bank_id):
-            # Verify it has a config.yaml
+            # Verify it has assessment.yaml or config.yaml
+            assessment_blob = bucket.blob(f"{prefix}{bank_id}/assessment.yaml")
             config_blob = bucket.blob(f"{prefix}{bank_id}/config.yaml")
-            if config_blob.exists():
+            if assessment_blob.exists() or config_blob.exists():
                 bank_ids.append(bank_id)
 
     return sorted(bank_ids)

--- a/backend/tests/test_teaching_storage.py
+++ b/backend/tests/test_teaching_storage.py
@@ -152,6 +152,7 @@ class TestListBanksInGcs:
 
         def blob_exists_side_effect(name: str) -> MagicMock:
             blob = MagicMock()
+            # has-config has assessment.yaml; no-config has neither
             blob.exists.return_value = "has-config" in name
             return blob
 
@@ -161,6 +162,32 @@ class TestListBanksInGcs:
         with patch.object(_gc, "storage", ms, create=True):
             result = list_banks_in_gcs("test-bucket")
         assert result == ["has-config"]
+
+    def test_finds_banks_with_assessment_yaml(self) -> None:
+        """Banks with assessment.yaml (modules layout) are discovered."""
+        mock_client = MagicMock()
+        mock_bucket = MagicMock()
+        mock_client.bucket.return_value = mock_bucket
+
+        mock_blobs = MagicMock()
+        mock_blobs.__iter__ = MagicMock(return_value=iter([]))
+        mock_blobs.prefixes = [
+            "questions/colonoscopy-test/",
+        ]
+        mock_bucket.list_blobs.return_value = mock_blobs
+
+        def blob_side_effect(name: str) -> MagicMock:
+            blob = MagicMock()
+            # Has assessment.yaml but NOT config.yaml
+            blob.exists.return_value = name.endswith("assessment.yaml")
+            return blob
+
+        mock_bucket.blob.side_effect = blob_side_effect
+
+        ms = _mock_gcs_client(mock_client)
+        with patch.object(_gc, "storage", ms, create=True):
+            result = list_banks_in_gcs("test-bucket")
+        assert result == ["colonoscopy-test"]
 
 
 class TestDownloadBankFromGcs:


### PR DESCRIPTION
…g.yaml

list_banks_in_gcs only checked for config.yaml, but teaching repos use assessment.yaml (synced from modules/<id>/assessment/). This caused sync to find 0 modules on production.

Now checks for assessment.yaml first, then config.yaml as fallback.