### PR TITLE
fix(teaching): show sync errors for banks not yet in database

### DIFF
--- a/frontend/src/pages/admin/teaching/AdminTeachingPage.test.tsx
+++ b/frontend/src/pages/admin/teaching/AdminTeachingPage.test.tsx
@@ -192,4 +192,28 @@ describe("AdminTeachingPage", () => {
       expect(screen.getByText("Download failed")).toBeTruthy();
     });
   });
+
+  it("shows errors for banks not yet in the database", async () => {
+    const user = userEvent.setup();
+
+    // No banks in DB initially
+    (api.get as Mock).mockResolvedValue([]);
+    (api.post as Mock).mockResolvedValue({
+      synced: [],
+      errors: [{ bank_id: "new-module", error: "module directory not found" }],
+    });
+
+    renderWithRouter(<AdminTeachingPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Sync all")).toBeTruthy();
+    });
+
+    await user.click(screen.getByText("Sync all"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Sync failed")).toBeTruthy();
+      expect(screen.getByText("module directory not found")).toBeTruthy();
+    });
+  });
 });

--- a/frontend/src/pages/admin/teaching/AdminTeachingPage.tsx
+++ b/frontend/src/pages/admin/teaching/AdminTeachingPage.tsx
@@ -31,7 +31,7 @@ function syncResultToModules(
   banks: AdminBank[],
   result: SyncAllResult,
 ): SyncModuleRow[] {
-  return banks.map((bank) => {
+  const rows: SyncModuleRow[] = banks.map((bank) => {
     const synced = result.synced.find(
       (s) => s.question_bank_id === bank.bank_id,
     );
@@ -72,6 +72,24 @@ function syncResultToModules(
       reason: "",
     };
   });
+
+  // Include errors for banks not already in the DB
+  const knownBankIds = new Set(banks.map((b) => b.bank_id));
+  for (const err of result.errors) {
+    if (!knownBankIds.has(err.bank_id)) {
+      rows.push({
+        bank_id: err.bank_id,
+        title: err.bank_id,
+        type: "—",
+        outcome: "error" as const,
+        version: 0,
+        item_count: 0,
+        reason: String(err.error),
+      });
+    }
+  }
+
+  return rows;
 }
 
 export default function AdminTeachingPage() {


### PR DESCRIPTION
When sync discovers new banks via GCS but they fail validation, the errors were silently lost because syncResultToModules only iterated over existing DB rows. Now appends error rows for banks in the sync response that aren't in the DB yet.