### PR TITLE
fix(teaching): show actual error message on sync failure

### DIFF
--- a/frontend/src/pages/admin/teaching/AdminTeachingPage.tsx
+++ b/frontend/src/pages/admin/teaching/AdminTeachingPage.tsx
@@ -127,7 +127,9 @@ export default function AdminTeachingPage() {
       setHasSynced(true);
       const summary = getSyncSummary(updatedModules);
       showMessage(summary);
-    } catch {
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Sync request failed unexpectedly";
       setModules((prev) =>
         prev.map((m) => ({
           ...m,
@@ -139,7 +141,7 @@ export default function AdminTeachingPage() {
       showMessage({
         variant: "error",
         title: "Sync failed",
-        description: "The sync request failed unexpectedly",
+        description: message,
       });
     } finally {
       setSyncing(false);


### PR DESCRIPTION
Display the backend error detail instead of a generic message, making it possible to diagnose sync issues from the UI.